### PR TITLE
fix coverage % sort. fix table header text overlaps. yarn install

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -4,3 +4,4 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
+yarn install

--- a/dist/scripts/table.js
+++ b/dist/scripts/table.js
@@ -29,7 +29,7 @@ function sortTable(table, col, reverse) {
   var c;
   reverse = -((+reverse) || -1);
   tr = tr.sort(function(a, b) {
-    return reverse * (a.cells[col].textContent.trim().localeCompare(b.cells[col].textContent.trim()));
+    return reverse * (a.cells[col].textContent.trim().localeCompare(b.cells[col].textContent.trim(), undefined, {numeric: true}));
   });
   for (i = 0; i < th.length; ++i) {
     for (c = 0; c < th[i].cells.length; ++c) {

--- a/dist/scripts/table.js
+++ b/dist/scripts/table.js
@@ -29,7 +29,7 @@ function sortTable(table, col, reverse) {
   var c;
   reverse = -((+reverse) || -1);
   tr = tr.sort(function(a, b) {
-    return reverse * (a.cells[col].textContent.trim().localeCompare(b.cells[col].textContent.trim(), undefined, {numeric: true}));
+    return reverse * a.cells[col].dataset.sortVal.localeCompare(b.cells[col].dataset.sortVal, undefined, {numeric: true});
   });
   for (i = 0; i < th.length; ++i) {
     for (c = 0; c < th[i].cells.length; ++c) {

--- a/dist/styles/table.scss
+++ b/dist/styles/table.scss
@@ -1,3 +1,7 @@
+.mdc-data-table {
+  width: 100%;
+}
+
 table {
   border: {
     spacing: 0;
@@ -5,9 +9,9 @@ table {
   max: {
     width: 100%;
   }
-  table: {
-    layout: fixed;
-  }
+  // table: {
+    // layout: fixed;
+  // }
 
   width: 100%;
 

--- a/dist/styles/table.scss
+++ b/dist/styles/table.scss
@@ -1,7 +1,3 @@
-.mdc-data-table {
-  width: 100%;
-}
-
 table {
   border: {
     spacing: 0;
@@ -9,9 +5,9 @@ table {
   max: {
     width: 100%;
   }
-  // table: {
-    // layout: fixed;
-  // }
+  table: {
+    layout: fixed;
+  }
 
   width: 100%;
 
@@ -36,15 +32,15 @@ table {
         }
 
         &.width-50 {
-          width: 50%;
+          width: 38%;
         }
 
         &.width-5 {
-          width: 5%;
+          width: 7%;
         }
 
         &.width-9 {
-          width: 9%;
+          width: 11%;
         }
 
         .overflow {

--- a/lib/simplecov-material/version.rb
+++ b/lib/simplecov-material/version.rb
@@ -3,7 +3,7 @@
 module SimpleCov
   module Formatter
     class MaterialFormatter
-      VERSION = "0.4.0"
+      VERSION = "0.4.1"
     end
   end
 end

--- a/lib/simplecov-material/version.rb
+++ b/lib/simplecov-material/version.rb
@@ -3,7 +3,7 @@
 module SimpleCov
   module Formatter
     class MaterialFormatter
-      VERSION = "0.4.1"
+      VERSION = "0.4.0"
     end
   end
 end

--- a/views/group_page.erb
+++ b/views/group_page.erb
@@ -116,27 +116,27 @@
           <% files.each do |source_file| %>
             <tr class="mdc-data-table__row clickable" name="<%= shortened_filename(source_file) %>"
                 onclick="openModal(this.attributes.name.value)">
-              <td class="width-50" title="<%= shortened_filename(source_file) %>">
+              <td class="width-50" title="<%= shortened_filename(source_file) %>" data-sort-val="<%= shortened_filename(source_file) %>">
                 <div class="overflow">
                   <%= shortened_filename(source_file) %>
                 </div>
               </td>
-              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-9 <%= coverage_class(source_file.covered_percent) %>">
+              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-9 <%= coverage_class(source_file.covered_percent) %>" data-sort-val="<%= source_file.covered_percent.round(2).to_s %>">
                 <%= source_file.covered_percent.round(2).to_s %>%
               </td>
-              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-5">
+              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-5" data-sort-val="<%= source_file.lines.count %>">
                 <%= format_number(source_file.lines.count) %>
               </td>
-              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-9">
+              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-9" data-sort-val="<%= source_file.covered_lines.count + source_file.missed_lines.count %>">
                 <%= format_number(source_file.covered_lines.count + source_file.missed_lines.count) %>
               </td>
-              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-9">
+              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-9" data-sort-val="<%= source_file.covered_lines.count %>">
                 <%= format_number(source_file.covered_lines.count) %>
               </td>
-              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-9">
+              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-9" data-sort-val="<%= source_file.missed_lines.count %>">
                 <%= format_number(source_file.missed_lines.count) %>
               </td>
-              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-9">
+              <td class="mdc-data-table__cell mdc-data-table__cell--numeric width-9" data-sort-val="<%= source_file.covered_strength %>">
                 <%= format_number(source_file.covered_strength) %>
               </td>
             </tr>


### PR DESCRIPTION
# Description

* Coverage sorting was sorting by string comparison. This switches it to numeric sorting. Closes issue #8, which I created
* Do not use a `fixed` table layout. This caused the header overlap. Let the table be a table and use the side-scrolling provided by overflow-x on the containing `.mdc-data-table` div
* added `yarn install` to the setup script. I had to manually do that, before I could `yarn test`. I figured it should be in the setup script.

I assigned it to version 0.4.1 in my local fork since I considered it more a bugfix.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing by seeing that the table header text no longer overlaps and that sorting is correct.

# Checklist:

- [X] My changes generate no new warnings
