### PR TITLE
added a space between to and path for coverage output

### DIFF
--- a/lib/simplecov-material.rb
+++ b/lib/simplecov-material.rb
@@ -25,7 +25,7 @@ module SimpleCov
       end
 
       def output_message(result)
-        "Coverage report generated for #{result.command_name} to" \
+        "Coverage report generated for #{result.command_name} to " \
         "#{output_path}. #{result.covered_lines} / #{result.total_lines} LOC" \
         " (#{result.covered_percent.round(2)}%) covered."
       end


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Just a string change to add a space between the word `to` and the path of the coverage output. 

```
$ rake spec
...rspec output

Coverage report generated for RSpec to/Users/yash/some_path_to_project/coverage. 13 / 13 LOC (100.0%) covered.

COVERAGE: 100.00% -- 13/13 lines in 2 files
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
