### PR TITLE
Reduce distributed files in the gem

### DIFF
--- a/simplecov-material.gemspec
+++ b/simplecov-material.gemspec
@@ -22,10 +22,16 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/chiefpansancolt/simplecov-material/blob/master/CHANGELOG.md"
   spec.metadata["bug_tracker_uri"] = "https://github.com/chiefpansancolt/simplecov-material/issues"
 
-  spec.files         = `git ls-files`.split("\n")
-  spec.bindir        = "bin"
-  spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  spec.files = Dir[
+    "dist/**/*",
+    "lib/**/*",
+    "public/**/*",
+    "views/**/*",
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md"
+  ]
+  spec.bindir = "bin"
   spec.require_paths = ["lib"]
 
   spec.add_dependency "simplecov", ">= 0.16.0"


### PR DESCRIPTION
# Description

I reduced the files distributed with the gem, in particular executables, it's a development scripts, they got put into the user $PATH and also conflict with other gems that I plan to send similar PRs too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `rake build`
- [x] `cd pkg`
- [x] `tar xf simplecov-material-1.0.0.gem`
- [x] `data.tar.gz`
- [x] `ls` and made sure only relevant files there

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
